### PR TITLE
Usage of `host` instead of `hostname`.

### DIFF
--- a/lib/rails-database-url.rb
+++ b/lib/rails-database-url.rb
@@ -34,7 +34,7 @@ module RailsDatabaseUrl
     end
     URI::Generic.new(config["adapter"],
                      user_info,
-                     config["hostname"] || "localhost",
+                     config["host"] || config["hostname"] || "localhost",
                      config["port"],
                      nil,
                      "/#{config["database"]}",


### PR DESCRIPTION
`config/database.yml` uses `host` as a key. `hostname` is left here as the first fallback only to avoid breakage for users whom might be still using `hostname`.

Thanks for this gem, Glenn!
