### PR TITLE
Use correct database.yml property for host name

### DIFF
--- a/lib/rails-database-url.rb
+++ b/lib/rails-database-url.rb
@@ -34,7 +34,7 @@ module RailsDatabaseUrl
     end
     URI::Generic.new(config["adapter"],
                      user_info,
-                     config["hostname"] || "localhost",
+                     config["host"] || "localhost",
                      config["port"],
                      nil,
                      "/#{config["database"]}",


### PR DESCRIPTION
From the documentation I can find, the correct property name here is actually "host", not "hostname" (see http://guides.rubyonrails.org/configuring.html#configuring-a-database). I deployed this gem on a hosting provider that had a separate database instance and it blew up on me because they also use "host" in the "database.yml". Changing this to match what seems to be the correct Rails name.
